### PR TITLE
Fix HTTPS connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV mqtt_pass=
 ENV enet_ip=
 ENV mqtt_ip=
 ENV mqtt_port=
+ENV uri_scheme=
 ENV verify_ssl_cert=
 
 RUN apt-get update && apt-get install --no-install-recommends -y gcc build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev libbz2-dev && apt-get install wget -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV mqtt_pass=
 ENV enet_ip=
 ENV mqtt_ip=
 ENV mqtt_port=
+ENV verify_ssl_cert=
 
 RUN apt-get update && apt-get install --no-install-recommends -y gcc build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev libbz2-dev && apt-get install wget -y
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install it two (three if you have unraid) ways:
 #### 1. From prebuild ([docker hub](https://hub.docker.com/repository/docker/th0masdb14/enet2mqtt))
 You can download the docker image and create the docker container by running this command (replace variables with correct information):
 
-    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
+    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e uri_scheme=[URI_SCHEME] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
  - [ENET_USER] = Your enet username
  - [ENET_PASSWORD] = Your enet password
  - [MQTT_USER] = your mqtt username of your broker
@@ -23,8 +23,9 @@ You can download the docker image and create the docker container by running thi
  - [ENET_IP] = your enet server IP
  - [MQTT_BROKER_IP] = your mqtt broker IP
  - [MQTT_PORT] = your mqtt broker port
- - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate
- 
+ - [URI_SCHEME] = http or https (defaults to http if not specified)
+ - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate (defaults to TRUE if not specified)
+
 That is it!
  
 #### 2. Or from source
@@ -34,7 +35,7 @@ First, you need to make a docker image.
 
 Now that you have the docker image, you can create the docker container (replace variables with correct information):
 
-    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
+    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e uri_scheme=[URI_SCHEME] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
  - [ENET_USER] = Your enet username
  - [ENET_PASSWORD] = Your enet password
  - [MQTT_USER] = your mqtt username of your broker
@@ -42,7 +43,8 @@ Now that you have the docker image, you can create the docker container (replace
  - [ENET_IP] = your enet server IP
  - [MQTT_BROKER_IP] = your mqtt broker IP
  - [MQTT_PORT] = your mqtt broker port
- - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate
+ - [URI_SCHEME] = http or https (defaults to http if not specified)
+ - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate (defaults to TRUE if not specified)
  
 That is it!
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install it two (three if you have unraid) ways:
 #### 1. From prebuild ([docker hub](https://hub.docker.com/repository/docker/th0masdb14/enet2mqtt))
 You can download the docker image and create the docker container by running this command (replace variables with correct information):
 
-    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] --name enet2mqtt th0masdb14/enet2mqtt:latest
+    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
  - [ENET_USER] = Your enet username
  - [ENET_PASSWORD] = Your enet password
  - [MQTT_USER] = your mqtt username of your broker
@@ -23,6 +23,7 @@ You can download the docker image and create the docker container by running thi
  - [ENET_IP] = your enet server IP
  - [MQTT_BROKER_IP] = your mqtt broker IP
  - [MQTT_PORT] = your mqtt broker port
+ - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate
  
 That is it!
  
@@ -33,7 +34,7 @@ First, you need to make a docker image.
 
 Now that you have the docker image, you can create the docker container (replace variables with correct information):
 
-    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] --name enet2mqtt th0masdb14/enet2mqtt:latest
+    sudo docker run -d -e enet_user=[ENET_USER] -e enet_pass=[ENET_PASSWORD] -e mqtt_user=[MQTT_USER] -e mqtt_pass=[MQTT_PASSWORD] -e enet_ip=[ENET_IP] -e mqtt_ip=[MQTT_BROKER_IP] -e mqtt_port=[MQTT_PORT] -e verify_ssl_cert=[VERIFY_SSL_CERT] --name enet2mqtt th0masdb14/enet2mqtt:latest
  - [ENET_USER] = Your enet username
  - [ENET_PASSWORD] = Your enet password
  - [MQTT_USER] = your mqtt username of your broker
@@ -41,6 +42,7 @@ Now that you have the docker image, you can create the docker container (replace
  - [ENET_IP] = your enet server IP
  - [MQTT_BROKER_IP] = your mqtt broker IP
  - [MQTT_PORT] = your mqtt broker port
+ - [VERIFY_SSL_CERT] = TRUE or FALSE if your enet server has an untrusted HTTPS certificate
  
 That is it!
 

--- a/enet.py
+++ b/enet.py
@@ -16,10 +16,11 @@ URL_VIZ="/jsonrpc/visualization"
 URL_COM="/jsonrpc/commissioning"
 
 class EnetClient:
-    def __init__(self, user, passwd, hostname, sslverify):
+    def __init__(self, user, passwd, hostname, urischeme, sslverify):
         self.user = user
         self.passwd = passwd
         self.hostname = hostname
+        self.urischeme = urischeme
         self._session = requests.Session()
         self._session.verify = sslverify.upper() == "TRUE"
         self._debug_requests = False
@@ -36,7 +37,7 @@ class EnetClient:
                "id":str(self._api_counter)
         }
         self._api_counter += 1
-        response = self._session.post("http://%s%s" % (self.hostname, url), json=req)
+        response = self._session.post("%s://%s%s" % (self.urischeme, self.hostname, url), json=req)
         if get_raw:
             return response
         if response.status_code >= 400:
@@ -107,7 +108,7 @@ class EnetClient:
         r = self.request(URL_MANAGEMENT, "userLoginDigest", response)
 
         # For some reason I don't get, this request has to be made for auth to work for following requests...
-        r = self._session.get("http://%s/wslclient.html?icp=6p1C8GeIi2FOOEfeA85a" % self.hostname)
+        r = self._session.get("%s://%s/wslclient.html?icp=6p1C8GeIi2FOOEfeA85a" % (self.urischeme, self.hostname))
 
 
     def get_links(self, deviceUIDs=[]):

--- a/enet.py
+++ b/enet.py
@@ -16,11 +16,12 @@ URL_VIZ="/jsonrpc/visualization"
 URL_COM="/jsonrpc/commissioning"
 
 class EnetClient:
-    def __init__(self, user, passwd, hostname):
+    def __init__(self, user, passwd, hostname, sslverify):
         self.user = user
         self.passwd = passwd
         self.hostname = hostname
         self._session = requests.Session()
+        self._session.verify = sslverify.upper() == "TRUE"
         self._debug_requests = False
         self._api_counter = 1
         self._cookie=""

--- a/enet2mqtt.py
+++ b/enet2mqtt.py
@@ -152,6 +152,7 @@ def parseargs():
     parser.add_argument('--mqtt_port', type=int, default=1883)
     parser.add_argument('--mqtt_user', default="")
     parser.add_argument('--mqtt_passwd', default="")
+    parser.add_argument('--uri_scheme', choices=['http', 'https'], default="http")
     parser.add_argument('--verify_ssl_cert', default="TRUE")
 
     args = parser.parse_args()
@@ -162,6 +163,6 @@ if __name__ == "__main__":
     args = parseargs()
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S')
     
-    enet_client = enet.EnetClient(args.enet_user, args.enet_passwd, args.enet_host, args.verify_ssl_cert)
+    enet_client = enet.EnetClient(args.enet_user, args.enet_passwd, args.enet_host, args.uri_scheme, args.verify_ssl_cert)
     bridge = Enet2MqttBridge(enet_client, args.mqtt_host, args.mqtt_port, args.mqtt_user, args.mqtt_passwd)
     rc = bridge.run()

--- a/enet2mqtt.py
+++ b/enet2mqtt.py
@@ -152,6 +152,7 @@ def parseargs():
     parser.add_argument('--mqtt_port', type=int, default=1883)
     parser.add_argument('--mqtt_user', default="")
     parser.add_argument('--mqtt_passwd', default="")
+    parser.add_argument('--verify_ssl_cert', default="TRUE")
 
     args = parser.parse_args()
     return args
@@ -161,6 +162,6 @@ if __name__ == "__main__":
     args = parseargs()
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S')
     
-    enet_client = enet.EnetClient(args.enet_user, args.enet_passwd, args.enet_host)
+    enet_client = enet.EnetClient(args.enet_user, args.enet_passwd, args.enet_host, args.verify_ssl_cert)
     bridge = Enet2MqttBridge(enet_client, args.mqtt_host, args.mqtt_port, args.mqtt_user, args.mqtt_passwd)
     rc = bridge.run()

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./usr/local/bin/python3.7 enet2mqtt.py --enet_user ${enet_user} --enet_passwd ${enet_pass} --mqtt_user ${mqtt_user} --mqtt_passwd ${mqtt_pass} --mqtt_port ${mqtt_port:-1883} ${enet_ip} ${mqtt_ip}
+./usr/local/bin/python3.7 enet2mqtt.py --enet_user ${enet_user} --enet_passwd ${enet_pass} --mqtt_user ${mqtt_user} --mqtt_passwd ${mqtt_pass} --mqtt_port ${mqtt_port:-1883} --verify_ssl_cert ${verify_ssl_cert:-TRUE} ${enet_ip} ${mqtt_ip}

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./usr/local/bin/python3.7 enet2mqtt.py --enet_user ${enet_user} --enet_passwd ${enet_pass} --mqtt_user ${mqtt_user} --mqtt_passwd ${mqtt_pass} --mqtt_port ${mqtt_port:-1883} --verify_ssl_cert ${verify_ssl_cert:-TRUE} ${enet_ip} ${mqtt_ip}
+./usr/local/bin/python3.7 enet2mqtt.py --enet_user ${enet_user} --enet_passwd ${enet_pass} --mqtt_user ${mqtt_user} --mqtt_passwd ${mqtt_pass} --mqtt_port ${mqtt_port:-1883} --uri_scheme ${uri_scheme:-http} --verify_ssl_cert ${verify_ssl_cert:-TRUE} ${enet_ip} ${mqtt_ip}


### PR DESCRIPTION
Added option to connect to ENET server over HTTPS using URI_SCHEME environment variable. If needed the verification of SSL certificates can be disabled by setting the VERIFY_SSL_CERT environment variable to FALSE.